### PR TITLE
fix(chatSpawn): 修复生成假人时会生成两次的问题

### DIFF
--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -101,7 +101,7 @@ commandRegistry.registerCommand('假人生成',withArgs)
 const withArgs_xyz_name = ({args,entity}:commandInfo)=>{
     let location: Vector3 = null
     let nameTag : string = null
-    if(args[1]==='批量')return
+    if (args[1] === '批量' || args.length < 2) return
 
     // xyz
     if(args.length>=2 && args.length<=3)


### PR DESCRIPTION
修复输入一次生成假人时 生成两个假人的问题，如图所示，其中第二个位于世界边境，如图所示

![image](https://github.com/user-attachments/assets/7a41d04a-9840-4d45-a1e7-7ee30ff9c51f)


似乎是带坐标生成的函数return判断不完善导致的，不带坐标生成时，`withArgs_xyz_name`内的生成也被运行，造成生成两次（`noArgs`和`withArgs_xyz_name`都被执行）

添加对于参数个数<2的判断就好了，修复后只会生成一次