### PR TITLE
fix(chatSpawn): 修复输入非法导致生成错误的 bug

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
 	"format_version": 2,
 	"header": {
-		"name": "§t1.21.30 v16 §e§lFlash§fFakePlayerPack",
+		"name": "§t1.21.30 v17 §e§lFlash§fFakePlayerPack",
 		"description": "【指定生成坐标-构建于1.21.30-支持1.21.2x-1.21.5x】1.21.30 \n开启实验性游戏内容（测试版 API）-游戏内输入“假人帮助”或“假人创建” 对着假人右键（蹲或不蹲是两个不同的菜单） 无关QQ群：122957051:",
 		"uuid": "aa101e99-abb4-448d-b58f-71e9da43064e",
 		"version": [
 			1,
 			21,
-			316
+			317
 		],
 		"min_engine_version": [
 			1,
@@ -20,7 +20,7 @@
 			"version": [
 				1,
 				21,
-				316
+				317
 			],
 			"type": "script",
 			"uuid": "10101e99-abc1-5488-ba76-71e9da441300",

--- a/packer.js
+++ b/packer.js
@@ -4,7 +4,7 @@ const archiver = require('archiver');
 
 const pack_name = '指定生成坐标-构建于1.21.30-支持1.21.2x-1.21.5x'
 const pack_version = [1,21,30];
-const fix_pack_version = 16
+const fix_pack_version = 17
 const min_engine_version = [1,21,20]
 
 // https://www.npmjs.com/package/@minecraft/server?activeTab=versions

--- a/tscripts/lib/xboyPackage/xyz_dododo.ts
+++ b/tscripts/lib/xboyPackage/xyz_dododo.ts
@@ -14,8 +14,12 @@ export function xyz_dododo(xyz:string[],playerLocation=[0,0,0]) : number[] {
     // 遍历分割后的数组
     xyz.forEach((part, index) => {
         // 否则直接解析为数字
-        if (!part.startsWith('~'))
-            return new_xyz[index] = Number(part);
+        if (!part.startsWith('~')) {
+            const data = Number(part);
+            if (Number.isFinite(data))
+                return new_xyz[index] = data;
+            throw new Error(['x', 'y', 'z'][index] + ' not a number');
+        }
 
         let data: number|string = part.slice(1) // 去掉~
         let op = ops[data[0]] // 存在风险
@@ -27,7 +31,7 @@ export function xyz_dododo(xyz:string[],playerLocation=[0,0,0]) : number[] {
         }
 
         data = Number(data)
-        if(isNaN(data))
+        if(!Number.isFinite(data))
             throw new Error(['x','y','z'][index] + ' not a number')
 
 

--- a/tscripts/lib/xboyPackage/xyz_dododo.ts
+++ b/tscripts/lib/xboyPackage/xyz_dododo.ts
@@ -8,16 +8,13 @@ ops['+'] = '+'
 ops['-'] = '-'
 
 export function xyz_dododo(xyz:string[],playerLocation=[0,0,0]) : number[] {
-    // 初始化x, y, z
-    let new_xyz = [0,0,0]
-
     // 遍历分割后的数组
-    xyz.forEach((part, index) => {
+    return xyz.map((part, index) => {
         // 否则直接解析为数字
         if (!part.startsWith('~')) {
             const data = Number(part);
             if (Number.isFinite(data))
-                return new_xyz[index] = data;
+                return data;
             throw new Error(['x', 'y', 'z'][index] + ' not a number');
         }
 
@@ -40,10 +37,8 @@ export function xyz_dododo(xyz:string[],playerLocation=[0,0,0]) : number[] {
         if(op === '-')
             data -= playerLocation[index]
 
-        new_xyz[index] = data
+        return data
     });
-
-    return new_xyz;
 }
 
 function xyz_dododo_test() {


### PR DESCRIPTION
修复用户输入形如 `ffpp a Infinity ~Infinity` 时的产生的意外（假人生成在边境，且无法再通过命令与之交互）

类似下图

![f01b9e09e751de05a596b46fafa1d3d7](https://github.com/user-attachments/assets/e668e03d-7ec9-4ff5-bbcb-2b13152e22f1)
