### PR TITLE
feat(chatSpawn): `假人生成` 允许只指定假人名称

### DIFF
--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -8,12 +8,17 @@ import {
     spawnSimulatedPlayerByNameTag
 } from '../main'
 import { type CommandInfo, commandManager, Command } from '../../lib/yumeCommand/CommandRegistry'
-import { Dimension, Vector3, world } from '@minecraft/server'
+import { Dimension, Vector3, world, type Player } from '@minecraft/server'
 import {xyz_dododo} from "../../lib/xboyPackage/xyz_dododo";
 
 const overworld = world.getDimension("overworld");
 
-const spawnAndRegisterSimulatedPlayer = (location: Vector3, dimension: Dimension, nameTag?: string): void => {
+const spawnAndRegisterSimulatedPlayer = (entity: Player | undefined, location: Vector3, dimension: Dimension, nameTag?: string): void => {
+    if (!initSucceed) {
+        entity?.sendMessage('[假人] 插件未初始化完成，请重试');
+        return;
+    }
+
     const PID = GetPID();
     const __FlashPlayer__ = world.scoreboard.getObjective('##FlashPlayer##');
     const simulatedPlayer: SimulatedPlayer = nameTag
@@ -32,10 +37,7 @@ const chatSpawnCommand = new Command();
 
 // 假人生成
 chatSpawnCommand.register(({ args }) => args.length === 0, ({ entity, location }) => {
-    if (!initSucceed)
-        return entity?.sendMessage('[假人] 插件未初始化完成，请重试');
-
-    spawnAndRegisterSimulatedPlayer(location, location.dimension);
+    spawnAndRegisterSimulatedPlayer(entity, location, location.dimension);
 });
 
 // 假人生成 批量 count
@@ -45,12 +47,12 @@ chatSpawnCommand.register(({ args }) => args[0] === '批量', ({ args: [, countS
 
     let count = Number(countString);
     while (count-- > 0)
-        spawnAndRegisterSimulatedPlayer(location, location.dimension);
+        spawnAndRegisterSimulatedPlayer(entity, location, location.dimension);
 });
 
 // 假人生成 name
-chatSpawnCommand.register(({ args }) => args.length === 1, ({ args: [targetName], location }) => {
-    spawnAndRegisterSimulatedPlayer(location, location.dimension, targetName);
+chatSpawnCommand.register(({ args }) => args.length === 1, ({ args: [targetName], entity, location }) => {
+    spawnAndRegisterSimulatedPlayer(entity, location, location.dimension, targetName);
 });
 
 // #56 参考：
@@ -96,7 +98,7 @@ chatSpawnCommand.register(
         }
         dimension ??= senderLocation.dimension ?? overworld;
 
-        spawnAndRegisterSimulatedPlayer(location, dimension, nameTag);
+        spawnAndRegisterSimulatedPlayer(entity, location, dimension, nameTag);
     }
 );
 

--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -48,6 +48,11 @@ chatSpawnCommand.register(({ args }) => args[0] === '批量', ({ args: [, countS
         spawnAndRegisterSimulatedPlayer(location, location.dimension);
 });
 
+// 假人生成 name
+chatSpawnCommand.register(({ args }) => args.length === 1, ({ args: [targetName], location }) => {
+    spawnAndRegisterSimulatedPlayer(location, location.dimension, targetName);
+});
+
 // #56 参考：
 // 假人生成 x y z name 维度序号（数字 0-主世界 1-下界 2-末地）
 chatSpawnCommand.register(

--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -30,6 +30,7 @@ const spawnAndRegisterSimulatedPlayer = (location: Vector3, dimension: Dimension
 
 const chatSpawnCommand = new Command();
 
+// 假人生成
 chatSpawnCommand.register(({ args }) => args.length === 0, ({ entity, location }) => {
     if (!initSucceed)
         return entity?.sendMessage('[假人] 插件未初始化完成，请重试');
@@ -37,6 +38,7 @@ chatSpawnCommand.register(({ args }) => args.length === 0, ({ entity, location }
     spawnAndRegisterSimulatedPlayer(location, location.dimension);
 });
 
+// 假人生成 批量 count
 chatSpawnCommand.register(({ args }) => args[0] === '批量', ({ args: [, countString], entity, location }) => {
     if (!countString) return entity?.sendMessage('[模拟玩家] 命令错误，请提供数字');
     if (!Number.isSafeInteger(Number(countString))) return entity?.sendMessage('[模拟玩家] 命令错误，期待数字却得到 ' + countString);

--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -13,81 +13,38 @@ import {xyz_dododo} from "../../lib/xboyPackage/xyz_dododo";
 
 const overworld = world.getDimension("overworld");
 
-
-const chatSpawnCommand = new Command()
-
-chatSpawnCommand.register(({args})=>args.length === 0, ({entity,location,isEntity})=>{
-    if(!initSucceed)
-        return entity?.sendMessage('[假人] 插件未初始化完成，请重试')
-    // TEST with pid input
-
-    if (isEntity) {
-        const PID = GetPID()
-        const __FlashPlayer__ = world.scoreboard.getObjective('##FlashPlayer##')
-        const simulatedPlayer: SimulatedPlayer = spawnSimulatedPlayer(location, location.dimension, PID)
+const spawnAndRegisterSimulatedPlayer = (location: Vector3, dimension: Dimension, nameTag?: string): void => {
+    const PID = GetPID();
+    const __FlashPlayer__ = world.scoreboard.getObjective('##FlashPlayer##');
+    const simulatedPlayer: SimulatedPlayer = nameTag
+        ? spawnSimulatedPlayerByNameTag(location, dimension, nameTag)
+        : spawnSimulatedPlayer(location, dimension, PID);
 
 
-        simulatedPlayers[PID] = simulatedPlayer
-        simulatedPlayers[simulatedPlayer.id] = PID
+    simulatedPlayers[PID] = simulatedPlayer;
+    simulatedPlayers[simulatedPlayer.id] = PID;
 
-        spawnedEvent.trigger({spawnedSimulatedPlayer: simulatedPlayer, PID})
-        // __FlashPlayer__.setScore(SimulatedPlayer,pid) //Score方案 因为无法为模拟玩家设置分数而放弃
-        __FlashPlayer__.setScore(simulatedPlayer.id, PID)
+    spawnedEvent.trigger({ spawnedSimulatedPlayer: simulatedPlayer, PID });
+    __FlashPlayer__.setScore(simulatedPlayer.id, PID);
+};
 
-        // ScoreBase.AddPoints(<ScoreboardObjective>ScoreBase.GetObject('##FlashPlayer##'),1)
-        // const pidParticipant = __FlashPlayer__.getParticipants().find(P=>P.displayName==='##currentPID')
+const chatSpawnCommand = new Command();
 
-        // TEST END
-    } else {
-        const PID = GetPID()
-        const __FlashPlayer__ = world.scoreboard.getObjective('##FlashPlayer##')
-        const simulatedPlayer: SimulatedPlayer = spawnSimulatedPlayer(location, location.dimension, PID)
+chatSpawnCommand.register(({ args }) => args.length === 0, ({ entity, location }) => {
+    if (!initSucceed)
+        return entity?.sendMessage('[假人] 插件未初始化完成，请重试');
 
+    spawnAndRegisterSimulatedPlayer(location, location.dimension);
+});
 
-        simulatedPlayers[PID] = simulatedPlayer
-        simulatedPlayers[simulatedPlayer.id] = PID
-
-        spawnedEvent.trigger({spawnedSimulatedPlayer: simulatedPlayer, PID})
-        // __FlashPlayer__.setScore(SimulatedPlayer,pid) //Score方案 因为无法为模拟玩家设置分数而放弃
-        __FlashPlayer__.setScore(simulatedPlayer.id, PID)
-    }
-
-
-})
-
-chatSpawnCommand.register(({ args }) => args[0] === '批量', ({ args: [, countString], entity, location, isEntity }) => {
+chatSpawnCommand.register(({ args }) => args[0] === '批量', ({ args: [, countString], entity, location }) => {
     if (!countString) return entity?.sendMessage('[模拟玩家] 命令错误，请提供数字');
     if (!Number.isSafeInteger(Number(countString))) return entity?.sendMessage('[模拟玩家] 命令错误，期待数字却得到 ' + countString);
 
     let count = Number(countString);
     while (count-- > 0)
-        if (isEntity) {
-            const PID = GetPID()
-            const __FlashPlayer__ = world.scoreboard.getObjective('##FlashPlayer##')
-            const simulatedPlayer: SimulatedPlayer = spawnSimulatedPlayer(location, location.dimension, PID)
-
-
-            // add SimulatedPlayer to SimulatedPlayerList,by ues obj <key,value>
-            simulatedPlayers[PID] = simulatedPlayer
-            simulatedPlayers[simulatedPlayer.id] = PID
-
-            spawnedEvent.trigger({spawnedSimulatedPlayer: simulatedPlayer, PID})
-            __FlashPlayer__.setScore(simulatedPlayer.id, PID)
-
-        } else {
-            const PID = GetPID()
-            const __FlashPlayer__ = world.scoreboard.getObjective('##FlashPlayer##')
-            const simulatedPlayer: SimulatedPlayer = spawnSimulatedPlayer(location, location.dimension, PID)
-
-
-            // add SimulatedPlayer to SimulatedPlayerList,by ues obj <key,value>
-            simulatedPlayers[PID] = simulatedPlayer
-            simulatedPlayers[simulatedPlayer.id] = PID
-
-            spawnedEvent.trigger({spawnedSimulatedPlayer: simulatedPlayer, PID})
-            __FlashPlayer__.setScore(simulatedPlayer.id, PID)
-        }
-})
+        spawnAndRegisterSimulatedPlayer(location, location.dimension);
+});
 
 // #56 参考：
 // 假人生成 x y z name 维度序号（数字 0-主世界 1-下界 2-末地）
@@ -119,7 +76,7 @@ chatSpawnCommand.register(
 
         // name
         if (targetName) 
-                nameTag = targetName;
+            nameTag = targetName;
 
         // dimension
         let dimension: Dimension;
@@ -132,19 +89,7 @@ chatSpawnCommand.register(
         }
         dimension ??= senderLocation.dimension ?? overworld;
 
-        const PID = GetPID();
-        const __FlashPlayer__ =
-            world.scoreboard.getObjective('##FlashPlayer##');
-
-        const simulatedPlayer: SimulatedPlayer = nameTag
-            ? spawnSimulatedPlayerByNameTag(location, dimension, nameTag)
-            : spawnSimulatedPlayer(location, dimension, PID);
-
-        simulatedPlayers[PID] = simulatedPlayer;
-        simulatedPlayers[simulatedPlayer.id] = PID;
-
-        spawnedEvent.trigger({ spawnedSimulatedPlayer: simulatedPlayer, PID });
-        __FlashPlayer__.setScore(simulatedPlayer.id, PID);
+        spawnAndRegisterSimulatedPlayer(location, dimension, nameTag);
     }
 );
 

--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -102,7 +102,7 @@ chatSpawnCommand.register(
 
 // 捕获命令参数数量错误并提示
 chatSpawnCommand.register(({ args, entity }) => {
-    entity?.sendMessage(`[模拟玩家] 命令错误，期待3个坐标数字或1个名称字符串，得到个数为${args.length}`);
+    entity?.sendMessage(`[模拟玩家] 命令错误，期待3个坐标数字(x y z)或1个名称字符串("名称")，得到个数为${args.length}。带空格名称需用引号包裹`);
 });
 
 commandManager.registerCommand(['假人生成', '假人创建', 'ffpp'], chatSpawnCommand);

--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -91,7 +91,7 @@ chatSpawnCommand.register(
             try {
                 dimension = world.getDimension(['overworld', 'nether', 'the end'][Number(targetDimension)]);
             } catch (e) {
-                return entity?.sendMessage('[模拟玩家] 命令错误，期待序号作为维度（0-主世界 1-下界 2-末地）却得到 ' + targetDimension);
+                return entity?.sendMessage('[模拟玩家] 命令错误，期待序号作为维度 (0-主世界 1-下界 2-末地) 却得到 ' + targetDimension);
             }
         }
         dimension ??= senderLocation.dimension ?? overworld;

--- a/tscripts/xTerrain/plugins/chatSpawn.ts
+++ b/tscripts/xTerrain/plugins/chatSpawn.ts
@@ -102,7 +102,7 @@ chatSpawnCommand.register(
 
 // 捕获命令参数数量错误并提示
 chatSpawnCommand.register(({ args, entity }) => {
-    entity?.sendMessage('[模拟玩家] 命令错误，期待三个坐标数字，得到个数为' + args.length);
+    entity?.sendMessage(`[模拟玩家] 命令错误，期待3个坐标数字或1个名称字符串，得到个数为${args.length}`);
 });
 
 commandManager.registerCommand(['假人生成', '假人创建', 'ffpp'], chatSpawnCommand);

--- a/tscripts/xTerrain/plugins/help.ts
+++ b/tscripts/xTerrain/plugins/help.ts
@@ -87,6 +87,7 @@ helpCommand.register(({ args, isEntity }) => args.length === 0 && isEntity, ({ e
 helpCommand.register(({ args, isEntity }) => args.length > 0 && isEntity, ({ args: [item], entity }) => {
     const helpMessage =
         ({
+            "创建": ["创建示例", "假人创建", "假人创建 + 空格 + x y z", "假人创建 100 50 0", "假人创建 + 空格 + name", "假人创建 \"fake player\""],
             "销毁": ["销毁示例", "假人销毁 + 空格 + 序号", "假人销毁 1", "假人销毁 2"],
             "重生": ["重生示例", "假人重生 + 空格 + 序号", "假人重生 1", "假人重生 2"],
             "scriptevent": ["scriptevent 示例", "/scriptevent ffp:ffpp", "/scriptevent ffp:假人生成 100 50 0", "/scriptevent ffp:假人销毁 2"]


### PR DESCRIPTION
命令允许在不指定假人生成坐标的情况下，在玩家位置直接生成指定名称假人。输入时只需提供假人名称。

eg.

在玩家位置生成一个名为 `猪人塔假人` 的模拟玩家：
```
假人生成 猪人塔假人
# spawned simulated player named `猪人塔假人`.
```
如果名称包含空格：
```
假人生成 "猪人塔 假人"
# spawned simulated player named `猪人塔 假人`.
```

TODO:
---
1. - [x] [refactor(chatSpawn/spawnAndRegisterSimulatedPlayer): 提取重复代码为独立函数](https://github.com/PuppyOne/FlashFakePlayerPack/commit/9804fd15204dcbf0a332ed13dd68b4ca0c16bacf)
2. - [x] [feat(chatSpawn): `假人生成` 增加命令重载，允许只携带1个参数生成假人](https://github.com/PuppyOne/FlashFakePlayerPack/commit/82059fb77d1c6b52e11a21fe4fa99f37c39ce0b7)
3. - [x] fix(chatSpawn): 完善所有命令的 `假人插件未初始化完成` 提示
4. - [x] feat(chatSpawn): 更新命令参数错误提示
5. - [x] feat(help): 更新 `假人生成` 帮助信息