### PR TITLE
fix(killedBySimPlayer): 修复实体死亡事件的非预期情况

### DIFF
--- a/tscripts/@types/globalThis.d.ts
+++ b/tscripts/@types/globalThis.d.ts
@@ -1,7 +1,8 @@
 import {
     EntityEventOptions,
     Entity,
-    EntityHurtAfterEvent, Vector3,
+    Vector3,
+    type EntityDieAfterEvent,
 } from "@minecraft/server";
 
 
@@ -80,7 +81,7 @@ export class EntityDeadByHurtEventSignal {
  * another entity.
  */
 // @ts-ignore
-export class EntityDeadByHurtEvent extends EntityHurtAfterEvent {
+export class EntityDeadByHurtEvent extends EntityDieAfterEvent {
     // /**
     //  * A summary of the reason that damage was caused.
     //  */

--- a/tscripts/lib/xboyEvents/entityDeadByHurt.ts
+++ b/tscripts/lib/xboyEvents/entityDeadByHurt.ts
@@ -1,13 +1,13 @@
 import EventSignal from "./EventSignal"
 import type { EntityDeadByHurtEvent } from "../../@types/globalThis.d.ts";
-import { world } from "@minecraft/server";
+import { EntityDamageCause, world } from "@minecraft/server";
 
 const entityDeadByHurt = new EventSignal<EntityDeadByHurtEvent>()
 
 
 
-world.afterEvents.entityHurt.subscribe(event=>
-  event.hurtEntity.getComponent("minecraft:health")?.currentValue<=0 && entityDeadByHurt.trigger(event)
+world.afterEvents.entityDie.subscribe(event =>
+  event.damageSource.cause === EntityDamageCause.entityAttack && entityDeadByHurt.trigger(event)
 )
 
 /*

--- a/tscripts/lib/xboyEvents/entityDeadByHurt.ts
+++ b/tscripts/lib/xboyEvents/entityDeadByHurt.ts
@@ -7,7 +7,7 @@ const entityDeadByHurt = new EventSignal<EntityDeadByHurtEvent>()
 
 
 world.afterEvents.entityHurt.subscribe(event=>
-  event.hurtEntity.getComponent("minecraft:health").currentValue<=0 && entityDeadByHurt.trigger(event)
+  event.hurtEntity.getComponent("minecraft:health")?.currentValue<=0 && entityDeadByHurt.trigger(event)
 )
 
 /*

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -7,7 +7,7 @@ entityDeadByHurt.subscribe(({damageSource,hurtEntity})=>{
     if(!damageSource)return
 
     if(simulatedPlayers[hurtEntity.id])
-        return damageSource ?? damageSource?.damagingEntity['sendMessage']('玩不起，就别玩')
+        return damageSource?.damagingEntity['sendMessage']('玩不起，就别玩')
 
     const PID = simulatedPlayers[damageSource.damagingEntity.id]
     if(!PID)return

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -1,7 +1,6 @@
 import type { Player } from '@minecraft/server';
 import entityDeadByHurt from '../../lib/xboyEvents/entityDeadByHurt'
 import {simulatedPlayers} from '../main'
-import {SimulatedPlayer} from '@minecraft/server-gametest'
 
 entityDeadByHurt.subscribe(({ damageSource: { damagingEntity }, deadEntity }) => {
     if (deadEntity.typeId !== 'minecraft:player' || damagingEntity.typeId !== 'minecraft:player') return;

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -6,15 +6,8 @@ import {SimulatedPlayer} from '@minecraft/server-gametest'
 entityDeadByHurt.subscribe(({ damageSource: { damagingEntity }, deadEntity }) => {
     if (deadEntity.typeId !== 'minecraft:player' || damagingEntity.typeId !== 'minecraft:player') return;
 
-    if (simulatedPlayers[deadEntity.id])
-        return (<Player>damagingEntity).sendMessage('玩不起，就别玩');
+    if (!(deadEntity.id in simulatedPlayers || damagingEntity.id in simulatedPlayers)) return;
 
-    const PID = simulatedPlayers[damagingEntity.id];
-    if (!PID) return;
-
-    const SimPlayer = <SimulatedPlayer>simulatedPlayers[PID];
-
-    if (!SimPlayer) return;
-
+    (<Player>damagingEntity).sendMessage('玩不起，就别玩');
     (<Player>deadEntity).sendMessage('菜，就多练');
 });

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -3,11 +3,11 @@ import entityDeadByHurt from '../../lib/xboyEvents/entityDeadByHurt'
 import {simulatedPlayers} from '../main'
 import {SimulatedPlayer} from '@minecraft/server-gametest'
 
-entityDeadByHurt.subscribe(({damageSource,hurtEntity})=>{
-    if(hurtEntity.typeId !== 'minecraft:player')return
+entityDeadByHurt.subscribe(({damageSource,deadEntity})=>{
+    if(deadEntity.typeId !== 'minecraft:player')return
     if(!damageSource)return
 
-    if(simulatedPlayers[hurtEntity.id])
+    if(simulatedPlayers[deadEntity.id])
         return (<Player>damageSource?.damagingEntity).sendMessage('玩不起，就别玩')
 
     const PID = simulatedPlayers[damageSource.damagingEntity.id]
@@ -17,5 +17,5 @@ entityDeadByHurt.subscribe(({damageSource,hurtEntity})=>{
 
     if(!SimPlayer)return
 
-    (<Player>hurtEntity).sendMessage('菜，就多练')
+    (<Player>deadEntity).sendMessage('菜，就多练')
 })

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -8,7 +8,7 @@ entityDeadByHurt.subscribe(({damageSource,deadEntity})=>{
     if(!damageSource)return
 
     if(simulatedPlayers[deadEntity.id])
-        return (<Player>damageSource?.damagingEntity).sendMessage('玩不起，就别玩')
+        return (<Player>damageSource?.damagingEntity)?.sendMessage?.('玩不起，就别玩')
 
     const PID = simulatedPlayers[damageSource.damagingEntity.id]
     if(!PID)return

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -3,18 +3,18 @@ import entityDeadByHurt from '../../lib/xboyEvents/entityDeadByHurt'
 import {simulatedPlayers} from '../main'
 import {SimulatedPlayer} from '@minecraft/server-gametest'
 
-entityDeadByHurt.subscribe(({damageSource,deadEntity})=>{
-    if (deadEntity.typeId !== 'minecraft:player' || damageSource.damagingEntity.typeId !== 'minecraft:player') return
+entityDeadByHurt.subscribe(({ damageSource, deadEntity }) => {
+    if (deadEntity.typeId !== 'minecraft:player' || damageSource.damagingEntity.typeId !== 'minecraft:player') return;
 
-    if(simulatedPlayers[deadEntity.id])
-        return (<Player>damageSource.damagingEntity).sendMessage('玩不起，就别玩')
+    if (simulatedPlayers[deadEntity.id])
+        return (<Player>damageSource.damagingEntity).sendMessage('玩不起，就别玩');
 
-    const PID = simulatedPlayers[damageSource.damagingEntity.id]
-    if(!PID)return
+    const PID = simulatedPlayers[damageSource.damagingEntity.id];
+    if (!PID) return;
 
-    const SimPlayer = <SimulatedPlayer>simulatedPlayers[PID]
+    const SimPlayer = <SimulatedPlayer>simulatedPlayers[PID];
 
-    if(!SimPlayer)return
+    if (!SimPlayer) return;
 
-    (<Player>deadEntity).sendMessage('菜，就多练')
-})
+    (<Player>deadEntity).sendMessage('菜，就多练');
+});

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -3,13 +3,13 @@ import entityDeadByHurt from '../../lib/xboyEvents/entityDeadByHurt'
 import {simulatedPlayers} from '../main'
 import {SimulatedPlayer} from '@minecraft/server-gametest'
 
-entityDeadByHurt.subscribe(({ damageSource, deadEntity }) => {
-    if (deadEntity.typeId !== 'minecraft:player' || damageSource.damagingEntity.typeId !== 'minecraft:player') return;
+entityDeadByHurt.subscribe(({ damageSource: { damagingEntity }, deadEntity }) => {
+    if (deadEntity.typeId !== 'minecraft:player' || damagingEntity.typeId !== 'minecraft:player') return;
 
     if (simulatedPlayers[deadEntity.id])
-        return (<Player>damageSource.damagingEntity).sendMessage('玩不起，就别玩');
+        return (<Player>damagingEntity).sendMessage('玩不起，就别玩');
 
-    const PID = simulatedPlayers[damageSource.damagingEntity.id];
+    const PID = simulatedPlayers[damagingEntity.id];
     if (!PID) return;
 
     const SimPlayer = <SimulatedPlayer>simulatedPlayers[PID];

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -1,3 +1,4 @@
+import type { Player } from '@minecraft/server';
 import entityDeadByHurt from '../../lib/xboyEvents/entityDeadByHurt'
 import {simulatedPlayers} from '../main'
 import {SimulatedPlayer} from '@minecraft/server-gametest'
@@ -7,7 +8,7 @@ entityDeadByHurt.subscribe(({damageSource,hurtEntity})=>{
     if(!damageSource)return
 
     if(simulatedPlayers[hurtEntity.id])
-        return damageSource?.damagingEntity['sendMessage']('玩不起，就别玩')
+        return (<Player>damageSource?.damagingEntity).sendMessage('玩不起，就别玩')
 
     const PID = simulatedPlayers[damageSource.damagingEntity.id]
     if(!PID)return
@@ -16,5 +17,5 @@ entityDeadByHurt.subscribe(({damageSource,hurtEntity})=>{
 
     if(!SimPlayer)return
 
-    hurtEntity['sendMessage']('菜，就多练')
+    (<Player>hurtEntity).sendMessage('菜，就多练')
 })

--- a/tscripts/xTerrain/plugins/killedBySimPlayer.ts
+++ b/tscripts/xTerrain/plugins/killedBySimPlayer.ts
@@ -4,11 +4,10 @@ import {simulatedPlayers} from '../main'
 import {SimulatedPlayer} from '@minecraft/server-gametest'
 
 entityDeadByHurt.subscribe(({damageSource,deadEntity})=>{
-    if(deadEntity.typeId !== 'minecraft:player')return
-    if(!damageSource)return
+    if (deadEntity.typeId !== 'minecraft:player' || damageSource.damagingEntity.typeId !== 'minecraft:player') return
 
     if(simulatedPlayers[deadEntity.id])
-        return (<Player>damageSource?.damagingEntity)?.sendMessage?.('玩不起，就别玩')
+        return (<Player>damageSource.damagingEntity).sendMessage('玩不起，就别玩')
 
     const PID = simulatedPlayers[damageSource.damagingEntity.id]
     if(!PID)return


### PR DESCRIPTION
1. 使用 entityDie 事件重构 `EntityDeadByHurtEvent`
2. 修复错误的判空逻辑 #82
3. 增加必要的判空处理以避免空值访问 #81 

fix #82, fix #81