### PR TITLE
fix(breakBlock): 修改挖掘方块的获取方式 以修复一些问题

### DIFF
--- a/tscripts/xTerrain/plugins/breakBlock.ts
+++ b/tscripts/xTerrain/plugins/breakBlock.ts
@@ -44,8 +44,7 @@ const breaks = (/*awa:awa='awa'*/)=>
         // getHeadLocation
         // getViewDirection
         // 这是一会要用到的妙妙工具
-        // @ts-ignore
-        const man = <SimulatedPlayer>SimPlayer
+        const man = <SimulatedPlayer><unknown>SimPlayer
         const block =  man.getBlockFromViewDirection({maxDistance:6})?.block
         if (!block) return
 

--- a/tscripts/xTerrain/plugins/breakBlock.ts
+++ b/tscripts/xTerrain/plugins/breakBlock.ts
@@ -54,7 +54,7 @@ const breaks = (/*awa:awa='awa'*/)=>
         const viewDirection = man.getViewDirection()
         const headLocation = man.getHeadLocation()
         const time =  times.get(man.id) ?? 0
-        const whatCanISee =  Vector_addition(headLocation, Vector_multiplication_dot(viewDirection,time % 3 + 1))
+        const whatCanISee =  man.getBlockFromViewDirection({maxDistance:5}).block
         const dimension = <Dimension>man.dimension
         // dimension.spawnParticle('minecraft:endrod',headLocation)
 

--- a/tscripts/xTerrain/plugins/breakBlock.ts
+++ b/tscripts/xTerrain/plugins/breakBlock.ts
@@ -49,16 +49,16 @@ const breaks = (/*awa:awa='awa'*/)=>
         const viewDirection = man.getViewDirection()
         const headLocation = man.getHeadLocation()
         const time =  times.get(man.id) ?? 0
-        const whatCanISee =  man.getBlockFromViewDirection({maxDistance:5}).block
+        const block =  man.getBlockFromViewDirection({maxDistance:5})?.block
+        if (!block) return
+
         const dimension = <Dimension>man.dimension
         // dimension.spawnParticle('minecraft:endrod',headLocation)
 
 
-        const block = dimension.getBlock(testWorldLocation["worldBlockLocation"](Vector_subtract(whatCanISee, testWorldLocation)))
-
         time < 600 && dimension.spawnParticle('minecraft:endrod',Vector_addition(block.location, {x:0.5,y:0.5,z:0.5}))
         if (block.isValid() && !block.isLiquid && !block.isAir){
-            man.breakBlock(Vector_subtract(whatCanISee, testWorldLocation))
+            man.breakBlock(Vector_subtract(block, testWorldLocation))
         } else {
             times.set(man.id,time+1)
         }

--- a/tscripts/xTerrain/plugins/breakBlock.ts
+++ b/tscripts/xTerrain/plugins/breakBlock.ts
@@ -49,7 +49,7 @@ const breaks = (/*awa:awa='awa'*/)=>
         const viewDirection = man.getViewDirection()
         const headLocation = man.getHeadLocation()
         const time =  times.get(man.id) ?? 0
-        const block =  man.getBlockFromViewDirection({maxDistance:5})?.block
+        const block =  man.getBlockFromViewDirection({maxDistance:6})?.block
         if (!block) return
 
         const dimension = <Dimension>man.dimension

--- a/tscripts/xTerrain/plugins/breakBlock.ts
+++ b/tscripts/xTerrain/plugins/breakBlock.ts
@@ -10,11 +10,6 @@ import { getSimPlayer } from '../../lib/xboyPackage/Util'
 import { world, system } from "@minecraft/server"
 import SIGN from "../../lib/xboyPackage/YumeSignEnum";
 
-
-export const BreakBlockSimulatedPlayerList:Set<string> = new Set()
-
-
-
 const breakBlockCommand = new Command();
 breakBlockCommand.register(({ args }) => args.length === 0, ({ entity, isEntity }) => {
     if (!isEntity) {

--- a/tscripts/xTerrain/plugins/breakBlock.ts
+++ b/tscripts/xTerrain/plugins/breakBlock.ts
@@ -46,26 +46,14 @@ const breaks = (/*awa:awa='awa'*/)=>
         // 这是一会要用到的妙妙工具
         // @ts-ignore
         const man = <SimulatedPlayer>SimPlayer
-        const viewDirection = man.getViewDirection()
-        const headLocation = man.getHeadLocation()
-        const time =  times.get(man.id) ?? 0
         const block =  man.getBlockFromViewDirection({maxDistance:6})?.block
         if (!block) return
 
-        const dimension = <Dimension>man.dimension
-        // dimension.spawnParticle('minecraft:endrod',headLocation)
-
-
-        time < 600 && dimension.spawnParticle('minecraft:endrod',Vector_addition(block.location, {x:0.5,y:0.5,z:0.5}))
         if (block.isValid() && !block.isLiquid && !block.isAir){
             man.breakBlock(Vector_subtract(block, testWorldLocation))
-        } else {
-            times.set(man.id,time+1)
         }
     })
 
-
-const times = new Map<Player["id"],number>()
 system.runInterval(breaks,0) // 2 + 0 = 0
 
 // console.error('[假人]内置插件'+commandName+'加载成功')


### PR DESCRIPTION
重新将获取被挖掘方块的方式从手动计算坐标改为 `.getBlockFromViewDirection` API

closes #73 