### PR TITLE
refactor(yumeCommand): 修正异常警告文本常量的拼写错误 & 更新引用

### DIFF
--- a/tscripts/lib/yumeCommand/CommandRegistry.ts
+++ b/tscripts/lib/yumeCommand/CommandRegistry.ts
@@ -85,8 +85,8 @@ export function getLocationFromEntityLike(entity: {
     };
 }
 
-export const internalExceptionWaringText = '[模拟玩家] 出现内部异常，已尝试处理，请在GitHub进行反馈以免再次出现问题';
-export const cannotHandledExceptionWaringText = '[模拟玩家] 出现不可处理的内部异常，请在GitHub进行反馈';
+export const internalExceptionWarningText = '[模拟玩家] 出现内部异常，已尝试处理，请在GitHub进行反馈以免再次出现问题';
+export const cannotHandledExceptionWarningText = '[模拟玩家] 出现不可处理的内部异常，请在GitHub进行反馈';
 
 /**
  * @example

--- a/tscripts/lib/yumeCommand/scriptEventHandler.ts
+++ b/tscripts/lib/yumeCommand/scriptEventHandler.ts
@@ -9,7 +9,7 @@ import {
     commandManager,
     CommandNotFoundError,
     type CommandInfoNoArgs,
-    cannotHandledExceptionWaringText
+    cannotHandledExceptionWarningText
 } from "./CommandRegistry";
 
 const namespaces = ['ffp'];
@@ -78,6 +78,6 @@ system.afterEvents.scriptEventReceive.subscribe(e => {
         if (e instanceof CommandNotFoundError)
             commandInfoNoArgs?.entity?.sendMessage(`[模拟玩家] 命令错误，找不到命令: ${e.commandName}`);
         else
-            commandInfoNoArgs?.entity?.sendMessage(cannotHandledExceptionWaringText);
+            commandInfoNoArgs?.entity?.sendMessage(cannotHandledExceptionWarningText);
     }
 }, { namespaces });

--- a/tscripts/xTerrain/main.ts
+++ b/tscripts/xTerrain/main.ts
@@ -32,7 +32,7 @@ import './plugins/killedBySimPlayer'
 import './plugins/setting'
 import './plugins/showCommandsList'
 import {playerMove} from "../lib/xboyEvents/move";
-import { cannotHandledExceptionWaringText, CommandError, commandManager, getLocationFromEntityLike } from '../lib/yumeCommand/CommandRegistry';
+import { cannotHandledExceptionWarningText, CommandError, commandManager, getLocationFromEntityLike } from '../lib/yumeCommand/CommandRegistry';
 import '../lib/yumeCommand/scriptEventHandler'
 
 const overworld = world.getDimension('overworld')
@@ -172,7 +172,7 @@ world.beforeEvents.chatSend.subscribe(({message, sender}) => {
         } catch (e) {
             if (!(e instanceof CommandError)) {
                 console.error(e);
-                world.sendMessage(cannotHandledExceptionWaringText);
+                world.sendMessage(cannotHandledExceptionWarningText);
             }
         }
     });


### PR DESCRIPTION
- 将 'internalExceptionWaringText' 修正为 'internalExceptionWarningText'
- 将 'cannotHandledExceptionWaringText' 修正为 'cannotHandledExceptionWarningText'
- 更新相关文件中的引用，匹配新的变量名