### PR TITLE
fix(gui/rename): 修复 1.21.7x 版本无法使用 GUI 界面改名

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@minecraft/server": "2.0.0-beta.1.21.80-preview.22",
+        "@minecraft/server": "2.0.0-beta.1.21.70-stable",
         "@minecraft/server-gametest": "1.0.0-beta.1.21.40-preview.25",
-        "@minecraft/server-ui": "2.0.0-beta.1.21.80-preview.22",
+        "@minecraft/server-ui": "2.0.0-beta.1.21.70-stable",
         "archiver": "latest",
         "clean-webpack-plugin": "^4.0.0",
         "typescript": "^5.6.3",
@@ -115,9 +115,9 @@
       "license": "MIT"
     },
     "node_modules/@minecraft/server": {
-      "version": "2.0.0-beta.1.21.80-preview.22",
-      "resolved": "https://registry.npmmirror.com/@minecraft/server/-/server-2.0.0-beta.1.21.80-preview.22.tgz",
-      "integrity": "sha512-oRiWHqrO8ad4XGD4C8hU4TjWHH/o+An697i4p3s/bpGfShHIVzZ28BlyhRe38g3FGQ9J42oyfaqUVo0ZdxPsAg==",
+      "version": "2.0.0-beta.1.21.70-stable",
+      "resolved": "https://registry.npmmirror.com/@minecraft/server/-/server-2.0.0-beta.1.21.70-stable.tgz",
+      "integrity": "sha512-K2Lda/cMhOI3RgZ6zwi6KYRykYcWu9BHbxy33JeHf6RubO41e2NRQ03j7CHLL4rTWhMOGD2T/vbnkj17etZhbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -149,14 +149,14 @@
       }
     },
     "node_modules/@minecraft/server-ui": {
-      "version": "2.0.0-beta.1.21.80-preview.22",
-      "resolved": "https://registry.npmmirror.com/@minecraft/server-ui/-/server-ui-2.0.0-beta.1.21.80-preview.22.tgz",
-      "integrity": "sha512-Zwp6Z4H2vl3at9+mGFQt/7oaWWV22wWKWr9oObV7qJ0/MfvMZMu3rXeUQxFh7yqaTSrcf80xk3eag9EPtfiohg==",
+      "version": "2.0.0-beta.1.21.70-stable",
+      "resolved": "https://registry.npmmirror.com/@minecraft/server-ui/-/server-ui-2.0.0-beta.1.21.70-stable.tgz",
+      "integrity": "sha512-NYZD2Ru6bR7TCf5dayR+orqHlDLaHLa6Zr5MOS00avTRXGrr+FMseA2Pp4PPWRXh2EnMHaKoQcOuYe9aaJ2ZzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@minecraft/common": "^1.0.0",
-        "@minecraft/server": "^2.0.0-beta.1.21.80-preview.22"
+        "@minecraft/server": "^2.0.0-beta.1.21.70-stable"
       }
     },
     "node_modules/@minecraft/vanilla-data": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "build": "cd . && tsc && webpack && node packer.js"
   },
   "devDependencies": {
-    "@minecraft/server": "2.0.0-beta.1.21.80-preview.22",
+    "@minecraft/server": "2.0.0-beta.1.21.70-stable",
     "@minecraft/server-gametest": "1.0.0-beta.1.21.40-preview.25",
-    "@minecraft/server-ui": "2.0.0-beta.1.21.80-preview.22",
+    "@minecraft/server-ui": "2.0.0-beta.1.21.70-stable",
     "clean-webpack-plugin": "^4.0.0",
     "typescript": "^5.6.3",
     "webpack": "^5.95.0",

--- a/tscripts/lib/xboyPackage/YumeSignEnum.ts
+++ b/tscripts/lib/xboyPackage/YumeSignEnum.ts
@@ -74,7 +74,7 @@ export const BEHAVIOR_FUNCTION = {
     swapEquipment : (sim:SimulatedPlayer,player:Player)=>commandManager.execute('假人装备交换',{entity:player,sim}),
     rename: async (sim: SimulatedPlayer, player: Player) => {
         const modalForm = new ModalFormData().title("假人改名");
-        modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', { defaultValue: sim.nameTag });
+        modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', sim.nameTag);
         const { canceled, formValues } = await modalForm.show(<any>player);
         if (canceled) return;
 


### PR DESCRIPTION
疑似依赖版本更太高，导致1.21.7x的假人 GUI 界面点击改名无反应（控制台报错）

1. 恢复 `modalForm.textField()` 方法的参数传递方式，从对象字面量传参 `{ defaultValue: sim.nameTag }` 改回直接传递位置参数

2. 降级 Minecraft 依赖版本
  `@minecraft/server` 和 `@minecraft/server-ui`  由 `2.0.0-beta.1.21.80-preview.22` 降级至 `2.0.0-beta.1.21.70-stable`
