### PR TITLE
适配 1.21.80 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
     "format_version": 2,
     "header": {
-        "name": "§t1.21.71 v19 §e§lFlash§fFakePlayerPack",
-        "description": "【指令与GUI增强-构建于1.21.71-支持1.21.7x】1.21.71 \n开启实验性游戏内容（测试版 API）-游戏内输入“假人帮助”或“假人创建” 对着假人右键（蹲或不蹲是两个不同的菜单） 无关QQ群：122957051:",
+        "name": "§t1.21.71 v20 §e§lFlash§fFakePlayerPack",
+        "description": "【指令与GUI增强-构建于1.21.80-支持1.21.7x-1.21.8x】1.21.71 \n开启实验性游戏内容（测试版 API）-游戏内输入“假人帮助”或“假人创建” 对着假人右键（蹲或不蹲是两个不同的菜单） 无关QQ群：122957051:",
         "uuid": "aa101e99-abb4-448d-b58f-71e9da43064e",
         "version": [
             1,
             21,
-            729
+            730
         ],
         "min_engine_version": [
             1,
@@ -20,7 +20,7 @@
             "version": [
                 1,
                 21,
-                729
+                730
             ],
             "type": "script",
             "uuid": "10101e99-abc1-5488-ba76-71e9da441300",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@minecraft/server": "2.0.0-beta.1.21.70-stable",
+        "@minecraft/server": "2.0.0-beta.1.21.80-stable",
         "@minecraft/server-gametest": "1.0.0-beta.1.21.40-preview.25",
-        "@minecraft/server-ui": "2.0.0-beta.1.21.70-stable",
+        "@minecraft/server-ui": "2.0.0-beta.1.21.80-stable",
         "archiver": "latest",
         "clean-webpack-plugin": "^4.0.0",
         "typescript": "^5.6.3",
@@ -115,9 +115,9 @@
       "license": "MIT"
     },
     "node_modules/@minecraft/server": {
-      "version": "2.0.0-beta.1.21.70-stable",
-      "resolved": "https://registry.npmmirror.com/@minecraft/server/-/server-2.0.0-beta.1.21.70-stable.tgz",
-      "integrity": "sha512-K2Lda/cMhOI3RgZ6zwi6KYRykYcWu9BHbxy33JeHf6RubO41e2NRQ03j7CHLL4rTWhMOGD2T/vbnkj17etZhbg==",
+      "version": "2.0.0-beta.1.21.80-stable",
+      "resolved": "https://registry.npmmirror.com/@minecraft/server/-/server-2.0.0-beta.1.21.80-stable.tgz",
+      "integrity": "sha512-pA5vTV25etB2wywkpK0O7dU1X2DRvs6aeWZlRdlGpNDXPKBQC+3c+fnwwEZadxXqsbvUkXmU8LY0IZlc25pTkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -149,14 +149,14 @@
       }
     },
     "node_modules/@minecraft/server-ui": {
-      "version": "2.0.0-beta.1.21.70-stable",
-      "resolved": "https://registry.npmmirror.com/@minecraft/server-ui/-/server-ui-2.0.0-beta.1.21.70-stable.tgz",
-      "integrity": "sha512-NYZD2Ru6bR7TCf5dayR+orqHlDLaHLa6Zr5MOS00avTRXGrr+FMseA2Pp4PPWRXh2EnMHaKoQcOuYe9aaJ2ZzQ==",
+      "version": "2.0.0-beta.1.21.80-stable",
+      "resolved": "https://registry.npmmirror.com/@minecraft/server-ui/-/server-ui-2.0.0-beta.1.21.80-stable.tgz",
+      "integrity": "sha512-t222gVbv6QhGr6/yUNgHRXoQbD1qC+g92E+hVGqz8ANqI9ud18+UG+hfxaF9JCrNg71pv46PIi9oV5elVtz4oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@minecraft/common": "^1.0.0",
-        "@minecraft/server": "^2.0.0-beta.1.21.70-stable"
+        "@minecraft/server": "^2.0.0-beta.1.21.80-stable"
       }
     },
     "node_modules/@minecraft/vanilla-data": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "build": "cd . && tsc && webpack && node packer.js"
   },
   "devDependencies": {
-    "@minecraft/server": "2.0.0-beta.1.21.70-stable",
+    "@minecraft/server": "2.0.0-beta.1.21.80-stable",
     "@minecraft/server-gametest": "1.0.0-beta.1.21.40-preview.25",
-    "@minecraft/server-ui": "2.0.0-beta.1.21.70-stable",
+    "@minecraft/server-ui": "2.0.0-beta.1.21.80-stable",
     "clean-webpack-plugin": "^4.0.0",
     "typescript": "^5.6.3",
     "webpack": "^5.95.0",

--- a/packer.js
+++ b/packer.js
@@ -2,9 +2,9 @@ const fs = require('fs');
 const archiver = require('archiver');
 
 
-const pack_name = '指令与GUI增强-构建于1.21.71-支持1.21.7x'
+const pack_name = '指令与GUI增强-构建于1.21.80-支持1.21.7x-1.21.8x'
 const pack_version = [1,21,71];
-const fix_pack_version = 19
+const fix_pack_version = 20
 const min_engine_version = [1,21,70]
 
 const printFilePathOnly = process.argv.includes('--print-filepath-only')

--- a/tscripts/lib/xboyPackage/YumeSignEnum.ts
+++ b/tscripts/lib/xboyPackage/YumeSignEnum.ts
@@ -74,7 +74,14 @@ export const BEHAVIOR_FUNCTION = {
     swapEquipment : (sim:SimulatedPlayer,player:Player)=>commandManager.execute('假人装备交换',{entity:player,sim}),
     rename: async (sim: SimulatedPlayer, player: Player) => {
         const modalForm = new ModalFormData().title("假人改名");
-        modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', { defaultValue: sim.nameTag });
+
+        try {
+            modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', { defaultValue: sim.nameTag });
+        } catch {
+            // @ts-expect-error 如果不支持如上传参方式，回退到 1.21.7x 的方式
+            modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', sim.nameTag);
+        }
+        
         const { canceled, formValues } = await modalForm.show(<any>player);
         if (canceled) return;
 

--- a/tscripts/lib/xboyPackage/YumeSignEnum.ts
+++ b/tscripts/lib/xboyPackage/YumeSignEnum.ts
@@ -74,7 +74,7 @@ export const BEHAVIOR_FUNCTION = {
     swapEquipment : (sim:SimulatedPlayer,player:Player)=>commandManager.execute('假人装备交换',{entity:player,sim}),
     rename: async (sim: SimulatedPlayer, player: Player) => {
         const modalForm = new ModalFormData().title("假人改名");
-        modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', sim.nameTag);
+        modalForm.textField(`由 "${sim.nameTag}" 改为：`, '输入新名称', { defaultValue: sim.nameTag });
         const { canceled, formValues } = await modalForm.show(<any>player);
         if (canceled) return;
 

--- a/tscripts/main/preload.ts
+++ b/tscripts/main/preload.ts
@@ -1,6 +1,9 @@
+import { world } from "@minecraft/server";
 import "../lib/xboyEvents/preload.js"
 
-import ("./main.js") //这里是为了解决一个莫名其妙的1.21.50触发的bug，当包加载的时候，加载world的部分方法会崩。而异步可以解决
+world.afterEvents.worldLoad.subscribe(() => import("./main.js"))
+// 2025-5-8  1.21.80 又出问题 通过延迟到 worldLoad 事件解决
+//这里是为了解决一个莫名其妙的1.21.50触发的bug，当包加载的时候，加载world的部分方法会崩。而异步可以解决
 
 
 

--- a/tscripts/xTerrain/main.ts
+++ b/tscripts/xTerrain/main.ts
@@ -117,9 +117,6 @@ register('我是云梦', '假人', (test:Test) => {
 // .requiredSuccessfulAttempts(tickWaitTimes)
 // .padding(0)
 
-    // @ts-ignore
-    (world.afterEvents.worldInitialize ?? world.afterEvents['worldLoad']).subscribe(()=>{
-
     // 记分板PID初始化 写的烂 执行两次
     verify()
     verify()
@@ -132,7 +129,7 @@ register('我是云梦', '假人', (test:Test) => {
             world.sendMessage('[模拟玩家] 报错了，我也不知道为什么' + e);
         }
     });
-})
+
 
 let say = false
 playerMove.subscribe(()=>{


### PR DESCRIPTION
- 更新依赖版本至 `2.0.0-beta.1.21.80-stable`
- 更新版本号 `v20` 和包名描述

- 延迟主要代码异步加载时机至 worldLoad 事件
- 更改 GUI 改名功能的传参方式，尝试同时适配 1.21.7x 和 1.21.8x（但是暂时不确定 1.21.7x 是否可用）