### PR TITLE
fix(command): 使用命令时 使功能 `自动食用` 与 `自动丢三叉戟` 互斥

### DIFF
--- a/tscripts/xTerrain/plugins/command.ts
+++ b/tscripts/xTerrain/plugins/command.ts
@@ -34,8 +34,8 @@ world.afterEvents.chatSend.subscribe( event => {
             xboy("停止")()([SIGN.ATTACK_SIGN, SIGN.AUTO_ATTACK_SIGN, SIGN.AUTO_JUMP_SIGN,SIGN.AUTO_TRIDENT_SIGN,SIGN.AUTO_CONSUME_SIGN])
             xboy("开摆")()([SIGN.ATTACK_SIGN, SIGN.AUTO_ATTACK_SIGN, SIGN.AUTO_JUMP_SIGN])
             xboy("自动重生")([SIGN.AUTO_RESPAWN_SIGN])()
-            xboy("自动丢三叉戟")([SIGN.AUTO_TRIDENT_SIGN])()
-            xboy("自动食用")([SIGN.AUTO_CONSUME_SIGN])()
+            xboy("自动丢三叉戟")([SIGN.AUTO_TRIDENT_SIGN])([SIGN.AUTO_CONSUME_SIGN])
+            xboy("自动食用")([SIGN.AUTO_CONSUME_SIGN])([SIGN.AUTO_TRIDENT_SIGN])
             // 并不认为参数默认值在这里是什么好主意--2023-12-14
 
             const behavior = 消息 // 坏了，重新审阅代码发现命令行为真是这里控制的，怎么这么重要的东西和shit放在一起--2023-12-14


### PR DESCRIPTION
使用命令开启其中一个标签时，将清除另一个标签

这是由于两个标签不支持同时开启，同时开启时，`自动食用` 将失效

此更改不影响使用 GUI 时的同时开启